### PR TITLE
Fix formatting issues in docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -53,7 +53,7 @@ if [ $# -eq 0 ]; then
     proc_serial=1
     while [ $proc_result == 128 ]; do
         /home/steam/steamcmd/steamcmd.sh +login anonymous +quit
-        ./WSServer.sh "${LEVEL_NAME}" -server -SLIENT -log -UTF8Output -SteamServerName=\""${SERVER_NAME}"\" -MaxPlayers="${MAX_PLAYERS}" -backup="${BACKUP_SYNC_INTERVAL_SECONDS}" -saving="${SAVING_SYNC_INTERVAL_SECONDS}" -MULTIHOME=0.0.0.0 -Port="${GAME_PORT}" -QueryPort="${QUERY_PORT}" -EchoPort="${ECHO_PORT}" -online=Steam -forcepassthrough "${extra_opts[@]}" &
+        ./WSServer.sh "${LEVEL_NAME}" -server -SLIENT -log -UTF8Output -SteamServerName="${SERVER_NAME}" -MaxPlayers="${MAX_PLAYERS}" -backup="${BACKUP_SYNC_INTERVAL_SECONDS}" -saving="${SAVING_SYNC_INTERVAL_SECONDS}" -MULTIHOME=0.0.0.0 -Port="${GAME_PORT}" -QueryPort="${QUERY_PORT}" -EchoPort="${ECHO_PORT}" -online=Steam -forcepassthrough "${extra_opts[@]}" &
         proc_result=$?
         pid=$!
         echo pid=$pid result=$proc_result


### PR DESCRIPTION
Multiple escape sequences adding "Quotes" causes server naming issues.
Tested with the server name: H3xx Soulmask Name test | & ; < > ( ) $ ` \ " '
quotes were dropped from the name, but otherwise the changes fix the naming problem
Screenshot evidence attached.

<img width="2087" height="87" alt="image" src="https://github.com/user-attachments/assets/2cc30413-8a67-464e-8969-a7f114ce4f80" />


